### PR TITLE
Refactor id generation of the cache.

### DIFF
--- a/lib/funnel/percolator.ex
+++ b/lib/funnel/percolator.ex
@@ -46,7 +46,8 @@ defmodule Funnel.Percolator do
     [token, uuid] = String.split(match, "-")
     {:ok, cache} = Funnel.Caches.add token
     {:ok, response} = JSEX.encode([filter_id: uuid, body: body])
-    id = Funnel.Transistor.Cache.push(cache, response)
+    id = Funnel.Uuid.generate
+    Funnel.Transistor.Cache.push(cache, id, response)
     Funnel.Transistor.notify(token, id, response)
   end
 end

--- a/lib/funnel/transistor/cache_state.ex
+++ b/lib/funnel/transistor/cache_state.ex
@@ -1,2 +1,2 @@
-defrecord Funnel.Transistor.CacheState, index: 0, items: [], max: 10
+defrecord Funnel.Transistor.CacheState, items: [], max: 10
 

--- a/test/funnel/transistor/cache_test.exs
+++ b/test/funnel/transistor/cache_test.exs
@@ -2,6 +2,11 @@ defmodule Funnel.Transistor.CacheTest do
   use Funnel.TestCase, async: true
   alias Funnel.Transistor.Cache
 
+  defp fill_cache(pid) do
+    range = Range.new(0, 100)
+    Enum.each range, fn(id) -> Cache.push(pid, id, "Hello") end
+  end
+
   test "process is alive" do
     {:ok, pid} = Cache.start_link("alive")
     assert Process.alive?(pid)
@@ -9,42 +14,40 @@ defmodule Funnel.Transistor.CacheTest do
 
   test "adds item to the cache" do
     {:ok, pid} = Cache.start_link("items")
-    Cache.push(pid, "Hello")
+    Cache.push(pid, "toto", "Hello")
     item = List.first(Cache.list(pid))
-    assert item == [id: 1, item: "Hello"]
-    Cache.push(pid, "Bye")
+    assert item == [id: "toto", item: "Hello"]
+    Cache.push(pid, "roger", "Bye")
     item = List.last(Cache.list(pid))
-    assert item == [id: 2, item: "Bye"]
+    assert item == [id: "roger", item: "Bye"]
   end
 
   test "limits size of the cache" do
     {:ok, pid} = Cache.start_link("limits")
-    range = Range.new(0, 100)
-    Enum.each range, fn(_) -> Cache.push(pid, "Hello") end
+    fill_cache(pid)
     assert Enum.count(Cache.list(pid)) == 10
-    Cache.push(pid, "Bye")
+    Cache.push(pid, 102, "Bye")
     item = List.last(Cache.list(pid))
     assert item == [id: 102, item: "Bye"]
   end
 
   test "return a list from a given id" do
     {:ok, pid} = Cache.start_link("from_id")
-    range = Range.new(0, 100)
-    Enum.each range, fn(_) -> Cache.push(pid, "Hello") end
-    assert Enum.count(Cache.list(pid, 97)) == 4
+    fill_cache(pid)
+    assert Enum.count(Cache.list(pid, 97)) == 3
   end
 
-  test "return a list from an id older than cache" do
-    {:ok, pid} = Cache.start_link("older")
-    range = Range.new(0, 100)
-    Enum.each range, fn(_) -> Cache.push(pid, "Hello") end
-    assert Enum.count(Cache.list(pid, 0)) == 10
+  test "return a list from an id which is not an integer" do
+    {:ok, pid} = Cache.start_link("items")
+    Cache.push(pid, "toto", "Hello")
+    Cache.push(pid, "roger", "Bye")
+    items = Cache.list(pid, "toto")
+    assert items == [[id: "roger", item: "Bye"]]
   end
 
   test "return a list with an unknow id" do
     {:ok, pid} = Cache.start_link("unknow")
-    range = Range.new(0, 100)
-    Enum.each range, fn(_) -> Cache.push(pid, "Hello") end
+    fill_cache(pid)
     assert Enum.count(Cache.list(pid, 443662456)) == 0
   end
 end


### PR DESCRIPTION
The id is now generated within the percolator.
